### PR TITLE
fixed path handling for Windows in exportDoc routine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.vscode
+/.project
 /node_modules
 /out

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ const exportDoc = function(namespaces, format) {
   for (const ns of Object.keys(result.namespaces)) {
     const nsPath = path.join(basePath, ...ns.split('.'));
     const nsFilePath = path.join(nsPath, `index.${ext}`);
-    mkdirp.sync(nsFilePath.substring(0, nsFilePath.lastIndexOf('/')));
+    mkdirp.sync(nsFilePath.substring(0, nsFilePath.lastIndexOf(path.sep)));
     fs.writeFileSync(nsFilePath, result.namespaces[ns].index);
     for (const def of Object.keys(result.namespaces[ns].definitions)) {
       const name = `${def}.${ext}`;


### PR DESCRIPTION
fixed path handling for Windows in exportDoc routine. On windows, these paths use backslash separators